### PR TITLE
Fix SageMath Snippets

### DIFF
--- a/src/sage/cython.yaml
+++ b/src/sage/cython.yaml
@@ -8,7 +8,7 @@ category: Miscellaneous / Cython
 title: "Cython Class"
 descr: "Defines a [Cython](https://cython.org/) class"
 code: |
-  %cython
+  %%cython
   cdef class MyClass:
       """
       This is a Cython class.

--- a/src/sage/numbertheory.yaml
+++ b/src/sage/numbertheory.yaml
@@ -128,7 +128,7 @@ title: "Galois Group"
 code: |
   R.<x> = PolynomialRing(QQ)
   K = NumberField(x^3 + x^2 - 2*x + 8, 'a')
-  K.galois_group(type="pari")
+  K.galois_group()
 ---
 title: "Quotient Polynomial Ring"
 code: |

--- a/src/sage/russ_plotting.yaml
+++ b/src/sage/russ_plotting.yaml
@@ -183,7 +183,7 @@ descr: |
   with the initial conditions $y(2) = 4$
   looks like.
 code: |
-  x = var('x')
+  x = var('x') 
   y = function('yy')(x)
   eq = diff(y, x) == - y/x - x + 2
   h = desolve(eq, y, [2, 4])
@@ -192,7 +192,7 @@ code: |
 
   # substituting the solution for y(x) in the right hand side
   substituted = eq.rhs().substitute_function(yy, sol)
-
+  y = var('y')
   P1 = plot_slope_field( substituted, (x, 0, 6), (y, -5, 15), headlength = 4, headaxislength=3 )
   P2 = plot( sol, (x, 0, 6), ymax=15, ymin=-5 )
   P = P1 + P2

--- a/src/sage/russ_plotting.yaml
+++ b/src/sage/russ_plotting.yaml
@@ -298,7 +298,7 @@ descr: >
 ---
 title: 4 Points
 code: |
-  show(points([(1,0), (sqrt(2)/2,sqrt(2)/2), (0,1), (1/2,1/2)], color='darkgreen', pointsize=50), aspect_ratio=1)
+  show(point([(1,0), (sqrt(2)/2,sqrt(2)/2), (0,1), (1/2,1/2)], color='darkgreen', pointsize=50), aspect_ratio=1)
 ---
 title: Line with point at the end
 code: |
@@ -377,7 +377,7 @@ descr: >
 ---
 title: Text with formula
 code: |
-  text(r"Text and LaTeX: $\\alpha^3 + 1$", (1,1), color="black", fontsize=15, rotation=30)
+  text(r"Text and LaTeX: $\alpha^3 + 1$", (1,1), color="black", fontsize=15, rotation=30)
 ---
 title: Lines
 code: |


### PR DESCRIPTION
This PR fixes most of the SageMath Snippets to work with SageMath 10.0. Only the following snippet still fails. 
```py
x = var('x')
y = function('yy')(x)
eq = diff(y, x) == - y/x - x + 2
h = desolve(eq, y, [2, 4])
sol(x) = h.expand()
print("solution:", sol)

# substituting the solution for y(x) in the right hand side
substituted = eq.rhs().substitute_function(yy, sol)

P1 = plot_slope_field( substituted, (x, 0, 6), (y, -5, 15), headlength = 4, headaxislength=3 )
P2 = plot( sol, (x, 0, 6), ymax=15, ymin=-5 )
P = P1 + P2
P2.show()
```
Fails with 
```py
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In [13], line 11
      8 # substituting the solution for y(x) in the right hand side
      9 substituted = eq.rhs().substitute_function(yy, sol)
---> 11 P1 = plot_slope_field( substituted, (x, Integer(0), Integer(6)), (y, -Integer(5), Integer(15)), headlength = Integer(4), headaxislength=Integer(3) )
     12 P2 = plot( sol, (x, Integer(0), Integer(6)), ymax=Integer(15), ymin=-Integer(5) )
     13 P = P1 + P2
File /ext/sage/10.0/src/sage/plot/plot_field.py:359, in plot_slope_field(f, xrange, yrange, **kwds)
    357     norm_inverse = 1 / sqrt((f**2+1))
    358     f_normalized = f * norm_inverse
--> 359 return plot_vector_field((norm_inverse, f_normalized), xrange, yrange, **slope_options)
File /ext/sage/10.0/src/sage/misc/decorators.py:496, in options.__call__.<locals>.wrapper(*args, **kwds)
    494     options['__original_opts'] = kwds
    495 options.update(kwds)
--> 496 return func(*args, **options)
File /ext/sage/10.0/src/sage/plot/plot_field.py:263, in plot_vector_field(f_g, xrange, yrange, **options)
    261 from sage.plot.all import Graphics
    262 from sage.plot.misc import setup_for_eval_on_grid
--> 263 z, ranges = setup_for_eval_on_grid([f,g], [xrange,yrange], options['plot_points'])
    264 f, g = z
    266 xpos_array, ypos_array, xvec_array, yvec_array = [], [], [], []
File /ext/sage/10.0/src/sage/plot/misc.py:210, in setup_for_eval_on_grid(funcs, ranges, plot_points, return_vars, imaginary_tolerance)
    208 # Handle vectors, lists, tuples, etc.
    209 if isinstance(funcs, Iterable):
--> 210     funcs = tuple( try_make_fast(f) for f in funcs )
    211 else:
    212     funcs = try_make_fast(funcs)
File /ext/sage/10.0/src/sage/plot/misc.py:210, in <genexpr>(.0)
    208 # Handle vectors, lists, tuples, etc.
    209 if isinstance(funcs, Iterable):
--> 210     funcs = tuple( try_make_fast(f) for f in funcs )
    211 else:
    212     funcs = try_make_fast(funcs)
File /ext/sage/10.0/src/sage/plot/misc.py:186, in setup_for_eval_on_grid.<locals>.try_make_fast(f)
    183 from sage.ext.interpreters.wrapper_cdf import Wrapper_cdf
    185 if hasattr(f, '_fast_callable_'):
--> 186     ff = fast_callable(f, vars=vars, expect_one_var=eov, domain=CDF)
    187     return FastCallablePlotWrapper(ff, imag_tol=imaginary_tolerance)
    188 elif isinstance(f, Wrapper_cdf):
    189     # Already a fast-callable, just wrap it. This can happen
    190     # if, for example, a symbolic expression is passed to a
    191     # higher-level plot() function that converts it to a
    192     # fast-callable with expr._plot_fast_callable() before
    193     # we ever see it.
File /ext/sage/10.0/src/sage/ext/fast_callable.pyx:454, in sage.ext.fast_callable.fast_callable()
    452     vars = [to_var(var) for var in vars]
    453     # Convert to a callable symbolic expression
--> 454     x = x.function(*vars)
    455 
    456 if vars is None:
File /ext/sage/10.0/src/sage/symbolic/expression.pyx:6821, in sage.symbolic.expression.Expression.function()
   6819         R = CallableSymbolicExpressionRing(args, check=False)
   6820         return R(self)
-> 6821     raise TypeError(f"must construct a function with symbolic variables as arguments, got {args}.")
   6822 
   6823 ############################################################################
TypeError: must construct a function with symbolic variables as arguments, got (x, yy(x)).
```
And I'm not sure how to fix it. 
Thank you